### PR TITLE
收藏夹内crash

### DIFF
--- a/nga_phone_base_3.0/src/sp/phone/task/JsonTopicListLoadTask.java
+++ b/nga_phone_base_3.0/src/sp/phone/task/JsonTopicListLoadTask.java
@@ -224,7 +224,7 @@ public class JsonTopicListLoadTask extends AsyncTask<String, Integer, TopicListI
 		{
 			ActivityUtil.getInstance().noticeError
 			(error, context);
-			//return;
+			return;
 		}
 		if(null != notifier)
 			notifier.jsonfinishLoad(result);


### PR DESCRIPTION
收藏夹到底部没有更多内容时JsonTopicListLoadTask中onPostExecute方法得到null参数 引发NullPointerException
